### PR TITLE
Fixed handle and iterator memory leaks

### DIFF
--- a/src/grib_df.c
+++ b/src/grib_df.c
@@ -60,8 +60,10 @@ SEXP gribr_grib_df(SEXP gribr_fileHandle, SEXP gribr_filter, SEXP gribr_namespac
       while(codes_keys_iterator_next(keyIter)) {
         m++;
       }
+      codes_keys_iterator_delete(keyIter);
     }
     toggle++;
+    codes_handle_delete(h);
   }
   if (err) {
     gerror("unable to count grib messages/keys", err);
@@ -90,6 +92,8 @@ SEXP gribr_grib_df(SEXP gribr_fileHandle, SEXP gribr_filter, SEXP gribr_namespac
       INTEGER(keyTypes)[i] = keyType;
       i++;
     }
+    codes_keys_iterator_delete(keyIter);
+    codes_handle_delete(h);
   }
   if (err) {
     gerror("unable to process table header", err);
@@ -189,16 +193,17 @@ SEXP gribr_grib_df(SEXP gribr_fileHandle, SEXP gribr_filter, SEXP gribr_namespac
       }
     }
     j++;
+    codes_keys_iterator_delete(keyIter);
+    codes_handle_delete(h);
   }
 
-  /* Be kind, please rewind. Without this the next call of grib_list will fail */
+  /* Be kind, please rewind. Without this the next call of grib_df will fail */
   grewind(file);
 
   /* Finalize data.frame attributes and class */
   classgets(gribr_grib_df, mkString("data.frame"));
   setAttrib(gribr_grib_df, R_RowNamesSymbol, rowNames);
 
-  codes_handle_delete(h);
   UNPROTECT(4);
   return gribr_grib_df;
 }

--- a/src/grib_get_message.c
+++ b/src/grib_get_message.c
@@ -35,12 +35,13 @@ SEXP gribr_grib_get_message(SEXP gribr_fileHandle, SEXP gribr_messages, SEXP gri
   count = 0;
   while((h = codes_grib_handle_new_from_file(DEFAULT_CONTEXT, file, &err))) {
     count++;
+    codes_handle_delete(h);
   }
   if (err) {
     gerror("unable to count grib messages", err);
   }
 
-  file = R_ExternalPtrAddr(gribr_fileHandle);
+  // file = R_ExternalPtrAddr(gribr_fileHandle);
   if (ftell(file) != 0) {
     fseek(file, 0, SEEK_SET);
   }
@@ -85,10 +86,10 @@ SEXP gribr_grib_get_message(SEXP gribr_fileHandle, SEXP gribr_messages, SEXP gri
       if ((p_gribr_messages[0] - 1) == i) {
         REPROTECT(gribr_message = gribr_message_from_handle(h, is_multi), pro_message);
       }
+      codes_handle_delete(h);
     }
   }
 
-  codes_handle_delete(h);
   grewind(file);
 
   UNPROTECT(1);

--- a/src/grib_length.c
+++ b/src/grib_length.c
@@ -20,6 +20,7 @@ SEXP gribr_grib_length(SEXP gribr_fileHandle) {
   n_on = 0;
   while((h = codes_grib_handle_new_from_file(DEFAULT_CONTEXT, file, &err))) {
     n_on++;
+    codes_handle_delete(h);
   }
   if (err) {
     gerror("unable to count grib messages", err);
@@ -29,8 +30,6 @@ SEXP gribr_grib_length(SEXP gribr_fileHandle) {
    * leave the file handle in a unusable state and cause
    * R to crash */
   grewind(file);
-
-  codes_handle_delete(h);
 
   if (n_on != n_off) {
     return ScalarInteger(n_on);

--- a/src/grib_list.c
+++ b/src/grib_list.c
@@ -16,6 +16,7 @@ SEXP gribr_grib_list(SEXP gribr_fileHandle, SEXP gribr_filter, SEXP gribr_namesp
   int filter;
   char value[MAX_VAL_LEN];
   size_t valueLength=MAX_VAL_LEN;
+  codes_keys_iterator* keyIter = NULL;
   SEXP gribr_grib_vec;
 
   filter = asInteger(gribr_filter);
@@ -36,6 +37,7 @@ SEXP gribr_grib_list(SEXP gribr_fileHandle, SEXP gribr_filter, SEXP gribr_namesp
   n = 0;
   while((h = codes_grib_handle_new_from_file(DEFAULT_CONTEXT, file, &err))) {
     n++;
+    codes_handle_delete(h);
   }
   if (err) {
     gerror("unable to count grib messages", err);
@@ -49,7 +51,6 @@ SEXP gribr_grib_list(SEXP gribr_fileHandle, SEXP gribr_filter, SEXP gribr_namesp
   /* The grib handle is our GRIB message iterator. Each time we call new_from_file,
      we are advancing to the next message in the file. */
   while((h = codes_grib_handle_new_from_file(DEFAULT_CONTEXT, file, &err)) != NULL) {
-    codes_keys_iterator* keyIter=NULL;
 
     if (h == NULL) {
       gerror("gribr: unable to create grib handle", err);
@@ -87,14 +88,12 @@ SEXP gribr_grib_list(SEXP gribr_fileHandle, SEXP gribr_filter, SEXP gribr_namesp
 
     codes_keys_iterator_delete(keyIter);
     codes_handle_delete(h);
-
   }
   /* Be kind, please rewind. Without this the next call of grib_list will fail */
   if (fseek(file, GRIB_FILE_START, SEEK_SET)) {
     error("gribr: unable to rewind file");
   }
 
-  codes_handle_delete(h);
   UNPROTECT(1);
   return gribr_grib_vec;
 }

--- a/src/grib_select.c
+++ b/src/grib_select.c
@@ -151,6 +151,7 @@ SEXP gribr_select(SEXP gribr_filePath, SEXP gribr_keyList, SEXP gribr_isMulti) {
         gerror("unable to create grib handle", err);
       }
       index_count++;
+      codes_handle_delete(hi);
     }
 
     if (index_count == 0) {
@@ -168,12 +169,12 @@ SEXP gribr_select(SEXP gribr_filePath, SEXP gribr_keyList, SEXP gribr_isMulti) {
       }
       SET_VECTOR_ELT(gribr_temp, m++,
                      gribr_message_from_handle(hi, is_multi));
+      codes_handle_delete(hi);
     }
     SET_VECTOR_ELT(gribr_selected, i, gribr_temp);
   }
 
   codes_handle_delete(h);
-  codes_handle_delete(hi);
   codes_index_delete(index);
 
   UNPROTECT(2);

--- a/src/gribr_internals.c
+++ b/src/gribr_internals.c
@@ -84,6 +84,7 @@ SEXP gribr_is_multi_message(SEXP fileHandle) {
   n_on = 0;
   while((h = codes_grib_handle_new_from_file(DEFAULT_CONTEXT, file, &err))) {
     n_on++;
+    codes_handle_delete(h);
   }
   if (err) {
     gerror("unable to count grib messages", err);
@@ -96,7 +97,7 @@ SEXP gribr_is_multi_message(SEXP fileHandle) {
     error("gribr: unable to rewind file");
   }
 
-  codes_handle_delete(h);
+  codes_grib_multi_support_off(DEFAULT_CONTEXT);
 
   if (n_on != n_off) {
     return ScalarLogical(TRUE);

--- a/src/message_from_handle.c
+++ b/src/message_from_handle.c
@@ -217,6 +217,8 @@ SEXP gribr_message_from_handle(codes_handle *h, int isMulti) {
     n++;
   }
 
+  codes_keys_iterator_delete(keyIter);
+
   if (bitmap) {
     nfree(bitmap);
   }


### PR DESCRIPTION
This fix will alleviate the issue of memory leaks occurring during
batch processing of GRIB files. There were several places that did not
delete ecCodes handle and iterator structures properly which led to the
leaks. Tests with larger numbers of files to process should be used
periodically.

Closes #10