### PR TITLE
Fix file descriptor leak; minor cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,161 @@ env:
 
 matrix:
   include:
-    - env: ECCODES_VERSION=2.1.0
+    - env: ECCODES_VERSION=2.0.0
       sudo: required
       os: linux
       dist: trusty
       r_check_args: --as-cran
       before_install: ./install_eccodes.sh
     - env: ECCODES_VERSION=2.1.0
+      sudo: required
+      os: linux
+      dist: trusty
+      r_check_args: --as-cran
+      before_install: ./install_eccodes.sh
+    - env: ECCODES_VERSION=2.2.0
+      sudo: required
+      os: linux
+      dist: trusty
+      r_check_args: --as-cran
+      before_install: ./install_eccodes.sh
+    - env: ECCODES_VERSION=2.3.0
+      sudo: required
+      os: linux
+      dist: trusty
+      r_check_args: --as-cran
+      before_install: ./install_eccodes.sh
+    - env: ECCODES_VERSION=2.4.0
+      sudo: required
+      os: linux
+      dist: trusty
+      r_check_args: --as-cran
+      before_install: ./install_eccodes.sh
+    - env: ECCODES_VERSION=2.5.0
+      sudo: required
+      os: linux
+      dist: trusty
+      r_check_args: --as-cran
+      before_install: ./install_eccodes.sh
+    - env: ECCODES_VERSION=2.6.0
+      sudo: required
+      os: linux
+      dist: trusty
+      r_check_args: --as-cran
+      before_install: ./install_eccodes.sh
+    - env: ECCODES_VERSION=2.7.0
+      sudo: required
+      os: linux
+      dist: trusty
+      r_check_args: --as-cran
+      before_install: ./install_eccodes.sh
+    - env:
+      - ECCODES_VERSION=2.0.0
+      - OPENJPEG_INCLUDE_DIR=/usr/local/include/openjpeg-2.3
+      latex: false
+      sudo: required
+      os: osx
+      r_check_args: --as-cran
+      before_install:
+        - brew update
+        - brew outdated libpng || brew upgrade libpng
+        - brew outdated lzlib || brew upgrade lzlib
+        - brew outdated jpeg || brew upgrade jpeg
+        - brew install openjpeg
+        - ./install_eccodes.sh
+    - env:
+      - ECCODES_VERSION=2.1.0
+      - OPENJPEG_INCLUDE_DIR=/usr/local/include/openjpeg-2.3
+      latex: false
+      sudo: required
+      os: osx
+      r_check_args: --as-cran
+      before_install:
+        - brew update
+        - brew outdated libpng || brew upgrade libpng
+        - brew outdated lzlib || brew upgrade lzlib
+        - brew outdated jpeg || brew upgrade jpeg
+        - brew install jasper
+        - brew install openjpeg
+        - ./install_eccodes.sh
+    - env:
+      - ECCODES_VERSION=2.2.0
+      - OPENJPEG_INCLUDE_DIR=/usr/local/include/openjpeg-2.3
+      latex: false
+      sudo: required
+      os: osx
+      r_check_args: --as-cran
+      before_install:
+        - brew update
+        - brew outdated libpng || brew upgrade libpng
+        - brew outdated lzlib || brew upgrade lzlib
+        - brew outdated jpeg || brew upgrade jpeg
+        - brew install jasper
+        - brew install openjpeg
+        - ./install_eccodes.sh
+    - env:
+      - ECCODES_VERSION=2.3.0
+      - OPENJPEG_INCLUDE_DIR=/usr/local/include/openjpeg-2.3
+      latex: false
+      sudo: required
+      os: osx
+      r_check_args: --as-cran
+      before_install:
+        - brew update
+        - brew outdated libpng || brew upgrade libpng
+        - brew outdated lzlib || brew upgrade lzlib
+        - brew outdated jpeg || brew upgrade jpeg
+        - brew install jasper
+        - brew install openjpeg
+        - ./install_eccodes.sh
+    - env:
+      - ECCODES_VERSION=2.4.0
+      - OPENJPEG_INCLUDE_DIR=/usr/local/include/openjpeg-2.3
+      latex: false
+      sudo: required
+      os: osx
+      r_check_args: --as-cran
+      before_install:
+        - brew update
+        - brew outdated libpng || brew upgrade libpng
+        - brew outdated lzlib || brew upgrade lzlib
+        - brew outdated jpeg || brew upgrade jpeg
+        - brew install jasper
+        - brew install openjpeg
+        - ./install_eccodes.sh
+    - env:
+      - ECCODES_VERSION=2.5.0
+      - OPENJPEG_INCLUDE_DIR=/usr/local/include/openjpeg-2.3
+      latex: false
+      sudo: required
+      os: osx
+      r_check_args: --as-cran
+      before_install:
+        - brew update
+        - brew outdated libpng || brew upgrade libpng
+        - brew outdated lzlib || brew upgrade lzlib
+        - brew outdated jpeg || brew upgrade jpeg
+        - brew install jasper
+        - brew install openjpeg
+        - ./install_eccodes.sh
+    - env:
+      - ECCODES_VERSION=2.6.0
+      - OPENJPEG_INCLUDE_DIR=/usr/local/include/openjpeg-2.3
+      latex: false
+      sudo: required
+      os: osx
+      r_check_args: --as-cran
+      before_install:
+        - brew update
+        - brew outdated libpng || brew upgrade libpng
+        - brew outdated lzlib || brew upgrade lzlib
+        - brew outdated jpeg || brew upgrade jpeg
+        - brew install jasper
+        - brew install openjpeg
+        - ./install_eccodes.sh
+    - env:
+      - ECCODES_VERSION=2.7.0
+      - OPENJPEG_INCLUDE_DIR=/usr/local/include/openjpeg-2.3
       latex: false
       sudo: required
       os: osx

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,11 @@
 Package: gribr
 Type: Package
 Title: Read GRIB Files
-Version: 1.2.1
+Version: 1.2.2
 Date: 2018-04-16
 Author: Nathan Wendt <nathan.wendt@noaa.gov>
 Maintainer: Nathan Wendt <nathan.wendt@noaa.gov>
+BugReports: https://github.com/nawendt/gribr/issues
 Description: R interface for GRIB files using ECMWF ecCodes. Easily read GRIB data into native R data types.
 License: BSD_2_clause + file LICENSE
 LazyData: TRUE

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([gribr], 1.2.0, [nawendt@ou.edu])
+AC_INIT([gribr], 1.2.0, [nathan.wendt@noaa.gov])
 
 m4_include([m4/gribr_link_eccodes.m4])
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,14 +3,14 @@ citHeader("To cite gribr in publications use:")
 citEntry(entry = "Manual",
   title        = "{gribr}: GRIB Interface for R using {ECMWF GRIB API}",
   author       = personList(as.person("Nathan Wendt")),
-  email        = "nawendt@ou.edu",
+  email        = "nathan.wendt@noaa.gov",
   year         = "2016",
   url          = "https://github.com/nawendt/gribr",
-  note         = "R package version 1.1.10",
+  note         = "R package version 1.2.2",
 
   textVersion  =
   paste("Nathan Wendt (2016).",
         "gribr: GRIB Interface for R using ECMWF GRIB API.",
-        "R package version 1.2.0.",
+        "R package version 1.2.2.",
         "https://github.com/nawendt/gribr.")
 )

--- a/install_eccodes.sh
+++ b/install_eccodes.sh
@@ -2,10 +2,28 @@
 
 cd $HOME
 echo Staging dependency files to $(pwd)
-curl -o eccodes-${ECCODES_VERSION}-Source.tar.gz https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-${ECCODES_VERSION}-Source.tar.gz?api=v2
+curl -o eccodes-${ECCODES_VERSION}-Source.tar.gz \
+        https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-${ECCODES_VERSION}-Source.tar.gz?api=v2
 tar -xzf eccodes-${ECCODES_VERSION}-Source.tar.gz
 cd eccodes-${ECCODES_VERSION}-Source
 mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_NETCDF=OFF -DENABLE_JPG=ON -DENABLE_PNG=ON -DENABLE_PYTHON=OFF -DENABLE_FORTRAN=OFF -DENABLE_EXAMPLES=OFF
+if [[ -n ${OPENJPEG_INCLUDE_DIR} ]]; then
+	cmake .. -DCMAKE_BUILD_TYPE=Release \
+	         -DENABLE_NETCDF=OFF \
+	         -DENABLE_JPG=ON \
+	         -DENABLE_PNG=ON \
+	         -DENABLE_PYTHON=OFF \
+	         -DENABLE_FORTRAN=OFF \
+	         -DENABLE_EXAMPLES=OFF \
+	         -DOPENJPEG_INCLUDE_DIR=${OPENJPEG_INCLUDE_DIR}
+else
+	cmake .. -DCMAKE_BUILD_TYPE=Release \
+	         -DENABLE_NETCDF=OFF \
+	         -DENABLE_JPG=ON \
+	         -DENABLE_PNG=ON \
+	         -DENABLE_PYTHON=OFF \
+	         -DENABLE_FORTRAN=OFF \
+	         -DENABLE_EXAMPLES=OFF
+fi
 make && sudo make install
 cd $TRAVIS_BUILD_DIR

--- a/src/grib_test.c
+++ b/src/grib_test.c
@@ -20,6 +20,14 @@ SEXP gribr_grib_test(SEXP gribr_fileName) {
   err = codes_count_in_file(DEFAULT_CONTEXT, gribFile, &count);
 
   /*
+   * CLOSE THE FILE HERE -- the GRIB file does not have an
+   * file handle for R to use yet. The file descriptor must
+   * be closed or it will leak and cause issues for
+   * large batch processing scripts.
+   */
+  fclose(gribFile);
+
+  /*
    * TRUE denotes the file is likely not a GRIB file. TRUE is
    * returned when there are 0 messages in the file or when
    * some sort of error has occurred trying to read the file


### PR DESCRIPTION
Main issue addressed in this commit is to fix the file descriptor leak
that existed in the GRIB file test of the file open process. This led
to users with large amounts of files to process to hit the per-process,
open file descriptor limit imposed by *nix systems. The file was
opened during the testing before the actual file handle was sent to R
and then never closed. Simply closig the file after the test alleviated
the problem.

Secondary to the descriptor leak, minor code cleaup occurred to update
the version and contact information. BugReports was added to the
DESCRIPTION in order to nudge users to that venue for bug reporting.

Fixes #12